### PR TITLE
Add About Us Page; Cleanup

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import Navbar from '@/components/Navbar.vue'
 import Footer from '@/components/Footer.vue'
-import SectionTitle from '@/components/SectionTitle.vue'
+import AboutUs from '@/components/AboutUs.vue'
 </script>
 
 <template>
   <div class="page">
     <Navbar></Navbar>
-    <SectionTitle title="About Us"></SectionTitle>
+    <AboutUs></AboutUs>
     <Footer></Footer>
   </div>
 </template>
@@ -15,8 +15,17 @@ import SectionTitle from '@/components/SectionTitle.vue'
 <style scoped>
 .page {
   display: flex;
-  align-items: center;
   flex-direction: column;
   min-height: 100vh;
 }
+
+.page > *:not(:last-child) {
+  flex-shrink: 0;
+}
+
+/* Let AboutUs grow and push Footer down */
+.page > .content {
+  flex: 1;
+}
+
 </style>

--- a/frontend/src/components/AboutUs.vue
+++ b/frontend/src/components/AboutUs.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import SectionTitle from '@/components/SectionTitle.vue'
+</script>
+
+<template>
+    <div class="page">
+        <SectionTitle title="About Us" />
+
+        <div class="about-us-content">
+            <p>
+                Open Sourcery is a club for students interested in collaborative software development,
+                especially open-source development, at the University of Maryland. Our goal is to provide
+                a space for both experienced developers and newcomers to improve their coding and project
+                management skills, acquire technical and open source experience through hands-on projects,
+                and foster connections with fellow students with an interest in open-source software.
+                Our focus is on project matchups and mentorship, as well as furthering the interest of
+                open-source development on campus.
+            </p>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+@import url('https://fonts.googleapis.com/css2?family=Jura:wght@300..700&display=swap');
+
+.page {
+    display: flex;
+    flex-direction: column;
+    margin: 0 auto;        /* Horizontally center the entire page box */
+    height: 90rem;
+    width: 58.25rem;
+}
+
+.about-us-content {
+    max-width: 1514.4rem;
+    margin-top: 2rem;      /* Space below SectionTitle */
+    font-size: 1.2rem;
+    line-height: 1.6;
+    color: #055665;
+    font-family: 'Jura';
+    font-weight: 500;
+}
+</style>

--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { defineProps } from 'vue'
 
 import logo from '#/open_sourcery.png'
 import discord from '#/Discord_Image.png'
@@ -64,32 +63,16 @@ const socials = [
 }
 
 .footer {
-  position: absolute;
-  /* Stay at the bottom of the screen */
-  bottom: 0;
-  /* Place it at the bottom */
-  left: 0;
-  /* Align it with the left edge */
   width: 100%;
-  /* Full width of the screen */
   height: 20.125rem;
-  /* Fixed height */
   display: flex;
-  /* Flexbox to position children */
   align-items: center;
-  /* Vertically center content */
-  gap: 1rem;
-  /* Space between items */
   justify-content: flex-start;
-  /* Align content to the left */
+  gap: 1rem;
   font-family: 'K2D';
-  /* Custom font */
   padding: 2rem 3rem;
-  /* Padding */
   background-color: #075180;
-  /* Footer background color */
   box-sizing: border-box;
-  /* Include padding in width calculation */
 }
 
 .socials {

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { defineProps } from 'vue'
 import logo from '#/open_sourcery.png'
 
 const props = defineProps<{

--- a/frontend/src/components/SectionTitle.vue
+++ b/frontend/src/components/SectionTitle.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { defineProps } from 'vue'
-
 const { title } = defineProps<{ title: string }>()
 </script>
 


### PR DESCRIPTION
Footer.vue and SectionTitle.vue had the following, which is no longer necessary as `defineProps` is now a compiler macro (which I didn't know while writing them)

Otherwise, added new page

```vue
<script setup lang="ts">
import { defineProps } from 'vue';
</script>```